### PR TITLE
Allow excluding files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,11 +17,11 @@ var JSCSFilter = function(inputTree, options) {
   }
 
   if (this.enabled) {
-    var rules = config.load(this.configPath || '.jscsrc') || {};
-    if (!(this.bypass = !Object.keys(rules).length)) {
+    this.rules = config.load(this.configPath || '.jscsrc') || {};
+    if (!(this.bypass = !Object.keys(this.rules).length)) {
       var checker = new jscs({ esnext: !!this.esnext });
       checker.registerDefaultRules();
-      checker.configure(rules);
+      checker.configure(this.rules);
       this.checker = checker;
 
       if (!this.disableTestGenerator) {
@@ -37,6 +37,10 @@ JSCSFilter.prototype.extensions = ['js'];
 JSCSFilter.prototype.targetExtension = 'js';
 JSCSFilter.prototype.processString = function(content, relativePath) {
   if (this.enabled && !this.bypass) {
+    if (this.rules.excludeFiles && this.rules.excludeFiles.indexOf(relativePath) > -1) {
+      return this.disableTestGenerator ? content : '';
+    }
+
     var errors = this.checker.checkString(content, relativePath);
 
     var errorText = this.processErrors(errors, true);

--- a/tests/fixtures/esnext-parse-error/.jscsrc
+++ b/tests/fixtures/esnext-parse-error/.jscsrc
@@ -1,0 +1,4 @@
+{
+  "esnext": true,
+  "excludeFiles": ["bad-file.js"]
+}

--- a/tests/fixtures/esnext-parse-error/bad-file.js
+++ b/tests/fixtures/esnext-parse-error/bad-file.js
@@ -1,0 +1,1 @@
+module foo from 'bar';

--- a/tests/fixtures/esnext-parse-error/good-file.js
+++ b/tests/fixtures/esnext-parse-error/good-file.js
@@ -1,0 +1,1 @@
+import foo from 'bar';

--- a/tests/index.js
+++ b/tests/index.js
@@ -203,6 +203,36 @@ describe('broccoli-jscs', function() {
         expect(readFile(dir + '/index.' + tree.targetExtension)).to.match(/ok\(true, 'index.js should pass jscs.'\);/);
       });
     });
+
+    it('generates empty content for excluded files with test generation', function() {
+      var sourcePath = 'tests/fixtures/esnext-parse-error';
+      chdir(sourcePath);
+
+      var tree = jscsTree('.');
+
+      builder = new broccoli.Builder(tree);
+      return builder.build().then(function(results) {
+        var dir = results.directory;
+        expect(readFile(dir + '/bad-file.' + tree.targetExtension)).to.be('');
+        expect(readFile(dir + '/good-file.' + tree.targetExtension)).to.match(/ok\(true, 'good-file.js should pass jscs.'\);/);
+      });
+    });
+
+    it('generates original content for excluded files without test generation', function() {
+      var sourcePath = 'tests/fixtures/esnext-parse-error';
+      chdir(sourcePath);
+
+      var tree = jscsTree('.', {
+        disableTestGenerator: true
+      });
+
+      builder = new broccoli.Builder(tree);
+      return builder.build().then(function(results) {
+        var dir = results.directory;
+        expect(readFile(dir + '/bad-file.' + tree.targetExtension)).to.be(readFile('bad-file.js'));
+        expect(readFile(dir + '/good-file.' + tree.targetExtension)).to.be(readFile('good-file.js'));
+      });
+    });
   });
 
   describe('escapeErrorString', function() {


### PR DESCRIPTION
jscs normally handles excluded files at the CLI level, so we can't take
advantage of it here.  This just adds it back with the same config used
upstream `excludeFiles`.
