### PR TITLE
Bump JSCS

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "broccoli-filter": "^0.1.10",
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-static-compiler": "^0.2.1",
-    "jscs": "1.8.1",
+    "jscs": "1.9.0",
     "path": "^0.4.9"
   },
   "devDependencies": {


### PR DESCRIPTION
The update doesn't seem to include changes that would break `broccoli-jscs`: https://github.com/jscs-dev/node-jscs/blob/master/CHANGELOG.md#version-190

(Also ran my fork on my ember-cli app w/out issues)