### PR TITLE
Update JSCS version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "broccoli-filter": "^0.1.10",
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-static-compiler": "^0.2.1",
-    "jscs": "1.8.1",
+    "jscs": "^1.10.0",
     "path": "^0.4.9"
   },
   "devDependencies": {


### PR DESCRIPTION
Also, allow updates within the 1.x series without manually bumping this package every time.