### PR TITLE
Allow excluding files by file glob matching

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var Filter = require('broccoli-filter');
 var jscs = require('jscs');
 var config = require('jscs/lib/cli-config');
 var path = require('path');
+var minimatch = require('minimatch');
 
 var JSCSFilter = function(inputTree, options) {
   if (!(this instanceof JSCSFilter)) return new JSCSFilter(inputTree, options);
@@ -37,8 +38,13 @@ JSCSFilter.prototype.extensions = ['js'];
 JSCSFilter.prototype.targetExtension = 'js';
 JSCSFilter.prototype.processString = function(content, relativePath) {
   if (this.enabled && !this.bypass) {
-    if (this.rules.excludeFiles && this.rules.excludeFiles.indexOf(relativePath) > -1) {
-      return this.disableTestGenerator ? content : '';
+    if (this.rules.excludeFiles) {
+      var excludeMatch = this.rules.excludeFiles.filter(function(excludeFileMatcher) {
+        return minimatch(relativePath, excludeFileMatcher);
+      });
+      if(excludeMatch && excludeMatch.length) {
+        return this.disableTestGenerator ? content : '';
+      }
     }
 
     var errors = this.checker.checkString(content, relativePath);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-static-compiler": "^0.2.1",
     "jscs": "^1.10.0",
+    "minimatch": "^2.0.1",
     "path": "^0.4.9"
   },
   "devDependencies": {

--- a/tests/fixtures/esnext-parse-error/.jscsrc
+++ b/tests/fixtures/esnext-parse-error/.jscsrc
@@ -1,4 +1,4 @@
 {
   "esnext": true,
-  "excludeFiles": ["bad-file.js"]
+  "excludeFiles": ["*bad-file.js"]
 }

--- a/tests/fixtures/esnext-parse-error/another-bad-file.js
+++ b/tests/fixtures/esnext-parse-error/another-bad-file.js
@@ -1,0 +1,1 @@
+module baz from 'qux';

--- a/tests/index.js
+++ b/tests/index.js
@@ -214,6 +214,7 @@ describe('broccoli-jscs', function() {
       return builder.build().then(function(results) {
         var dir = results.directory;
         expect(readFile(dir + '/bad-file.' + tree.targetExtension)).to.be('');
+        expect(readFile(dir + '/another-bad-file.' + tree.targetExtension)).to.be('');
         expect(readFile(dir + '/good-file.' + tree.targetExtension)).to.match(/ok\(true, 'good-file.js should pass jscs.'\);/);
       });
     });
@@ -230,6 +231,7 @@ describe('broccoli-jscs', function() {
       return builder.build().then(function(results) {
         var dir = results.directory;
         expect(readFile(dir + '/bad-file.' + tree.targetExtension)).to.be(readFile('bad-file.js'));
+        expect(readFile(dir + '/another-bad-file.' + tree.targetExtension)).to.be(readFile('another-bad-file.js'));
         expect(readFile(dir + '/good-file.' + tree.targetExtension)).to.be(readFile('good-file.js'));
       });
     });


### PR DESCRIPTION
Using [minimatch](https://github.com/isaacs/minimatch) to accomplish this

/cc @rwjblue - I'm just adding some functionality onto your [original commit to allow excluding files](https://github.com/kellyselden/broccoli-jscs/commit/f01108aabf981d1b30aa44f2f43ac881e244a6f8)