### PR TITLE
[FEATURE] File glob matching for "excludeFiles" with proper caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "broccoli": "^0.13.3",
     "expect.js": "^0.3.1",
+    "minimatch": "^2.0.1",
     "mocha": "^2.1.0"
   },
   "scripts": {

--- a/tests/fixtures/esnext-parse-error/.jscsrc
+++ b/tests/fixtures/esnext-parse-error/.jscsrc
@@ -1,4 +1,4 @@
 {
   "esnext": true,
-  "excludeFiles": ["bad-file.js"]
+  "excludeFiles": ["*bad-file.js"]
 }

--- a/tests/fixtures/esnext-parse-error/another-bad-file.js
+++ b/tests/fixtures/esnext-parse-error/another-bad-file.js
@@ -1,0 +1,1 @@
+module baz from 'qux';


### PR DESCRIPTION
This PR does the following:

- Implements glob matching for "excludeFiles" using [minimatch](https://github.com/isaacs/minimatch)
- Implements proper caching to ensure minimatch is only run once for each given relative path
- Tests the feature

Thanks to @rwjblue for all his help with this PR :+1: 