### PR TITLE
Fix: Updating minimatch from dev-dependency to dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-static-compiler": "^0.2.1",
     "jscs": "^1.10.0",
+    "minimatch": "^2.0.1",
     "path": "^0.4.9"
   },
   "devDependencies": {
     "broccoli": "^0.13.3",
     "expect.js": "^0.3.1",
-    "minimatch": "^2.0.1",
     "mocha": "^2.1.0"
   },
   "scripts": {


### PR DESCRIPTION
Small oversight on my previous PR https://github.com/kellyselden/broccoli-jscs/pull/13 . This is needed to correctly `npm install` minimatch as a dependency.

Should probably version :facepunch: this one