### PR TITLE
Ensure the output strings are properly escaped.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ var config    = require('jscs/lib/cli-config');
 var path      = require('path');
 var minimatch = require('minimatch');
 
+var jsStringEscape = require('js-string-escape');
+
 function _makeDictionary() {
   var cache = Object.create(null);
   cache['_dict'] = null;
@@ -90,12 +92,7 @@ JSCSFilter.prototype.logError = function(message) {
   console.log(message);
 };
 
-JSCSFilter.prototype.escapeErrorString = function(string) {
-  string = string.replace(/\n/gi, "\\n");
-  string = string.replace(/'/gi, "\\'");
-
-  return string;
-};
+JSCSFilter.prototype.escapeErrorString = jsStringEscape;
 
 JSCSFilter.prototype.shouldExcludeFile = function(relativePath) {
   if (this.rules.excludeFiles) {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "broccoli-filter": "^0.1.10",
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-static-compiler": "^0.2.1",
+    "js-string-escape": "^1.0.0",
     "jscs": "^1.10.0",
     "minimatch": "^2.0.1",
     "path": "^0.11.14"


### PR DESCRIPTION
Ember triggered a parse error on test output with the following string:

```javascript
compile('I can\'t believe it\'s not butter');
```