### PR TITLE
Use lintTree hook for ember-cli 0.1.10 and above.

### DIFF
--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -1,22 +1,38 @@
 var JSCSFilter = require('broccoli-jscs');
 var mergeTrees = require('broccoli-merge-trees');
 var pickFiles  = require('broccoli-static-compiler');
+var checker = require('ember-cli-version-checker');
 
 module.exports = {
   name: 'broccoli-jscs',
 
+  shouldSetupRegistryInIncluded: function() {
+    return !checker.isAbove(this, '0.1.10');
+  },
+
+  lintTree: function(type, tree) {
+    var jscsTree = new JSCSFilter(tree, this.app.options.jscsOptions);
+
+    if (!jscsTree.enabled || jscsTree.bypass || jscsTree.disableTestGenerator) {
+      return;
+    }
+
+    return jscsTree;
+  },
+
   included: function(app) {
+    var addonContext = this;
     this.app = app;
     this._super.included.apply(this, arguments);
 
-    if (app.tests) {
+    if (app.tests && this.shouldSetupRegistryInIncluded()) {
       app.registry.add('js', {
         name: 'broccoli-jscs',
         ext: 'js',
         toTree: function(tree, inputPath, outputPath, options) {
-          var jscsTree = new JSCSFilter(tree, app.options.jscsOptions);
+          var jscsTree = addonContext.lintTree('unknown-type', tree);
 
-          if (!jscsTree.enabled || jscsTree.bypass || jscsTree.disableTestGenerator) {
+          if (!jscsTree) {
             return tree;
           }
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "broccoli-filter": "^0.1.10",
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-static-compiler": "^0.2.1",
+    "ember-cli-version-checker": "^1.0.2",
     "js-string-escape": "^1.0.0",
     "jscs": "^1.10.0",
     "minimatch": "^2.0.1",


### PR DESCRIPTION
This prevents us from linting an addon's `app/` or `test-support/` tree.