### PR TITLE
Bumping JSCS version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "broccoli-static-compiler": "^0.2.1",
     "ember-cli-version-checker": "^1.0.2",
     "js-string-escape": "^1.0.0",
-    "jscs": "^1.10.0",
+    "jscs": "^1.11.3",
     "minimatch": "^2.0.1",
     "path": "^0.11.14"
   },


### PR DESCRIPTION
This is needed for the emberjs-build to unblock https://github.com/emberjs/ember.js/pull/10637.  I previously misread the version the bug was patched in.