### PR TITLE
Return tree to prevent breaking builds

### DIFF
--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -14,7 +14,7 @@ module.exports = {
     var jscsTree = new JSCSFilter(tree, this.app.options.jscsOptions);
 
     if (!jscsTree.enabled || jscsTree.bypass || jscsTree.disableTestGenerator) {
-      return;
+      return tree;
     }
 
     return jscsTree;


### PR DESCRIPTION
When using within an ember-cli (v0.2.0) project, and temporarily providing the `enabled: false` option, I would see the following errors and my ember-cli build would subsequently fail:

    Cleanup error.
    Cannot call method 'cleanup' of undefined
    ...
    Build failed.
    Invalid tree found. You must supply a path or an object with a `read` function: undefined

It seems reasonable to simply return the original `tree` in this context, so other Broccoli plugins can proceed as normal.

Edited to add: It doesn't seem like any test modifications are necessary as part of this (?), but let me know if that's not the case.