### PR TITLE
Updated JSCS to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "broccoli-static-compiler": "^0.2.1",
     "ember-cli-version-checker": "^1.0.2",
     "js-string-escape": "^1.0.0",
-    "jscs": "^1.12.0",
+    "jscs": "^2.0.0",
     "minimatch": "^2.0.1",
     "path": "^0.11.14"
   },


### PR DESCRIPTION
[JSCS changelog](https://github.com/jscs-dev/node-jscs/blob/master/CHANGELOG.md)

Adds es6 related rules, more reliable es6 parsing, new rules, etc. However there are a number of [backwards incompatible changes](https://github.com/jscs-dev/node-jscs/blob/master/CHANGELOG.md#changelog), so like you said, this probably warrants a minor version bump at least.