### PR TITLE
Upgrade to JSCS 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "broccoli-static-compiler": "^0.2.1",
     "ember-cli-version-checker": "^1.0.2",
     "js-string-escape": "^1.0.0",
-    "jscs": "^1.12.0",
+    "jscs": "^2.0.0",
     "minimatch": "^2.0.1",
     "path": "^0.11.14"
   },


### PR DESCRIPTION
We are using `broccoli-jscs` in [`ember-suave`](https://github.com/dockyard/ember-suave) and would love to upgrade to JSCS 2.0 so we can start doing the following without getting an [`Unexpected token`](https://github.com/jscs-dev/node-jscs/issues/1293) error:

```
const { get, set } = Ember;
```