### PR TITLE
quick hack to skip rebuilds if only the content of the source file ch…

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "js-string-escape": "^1.0.0",
     "jscs": "^2.0.0",
     "minimatch": "^2.0.1",
-    "path": "^0.11.14"
+    "path": "^0.11.14",
+    "symlink-or-copy": "^1.0.1"
   },
   "devDependencies": {
     "broccoli": "^0.15.0",


### PR DESCRIPTION
…anged (the jscs output doesn’t depend on the content input)

- [ ] implement this without the lol-hack, but on top of the latest broccoli-filter
- [ ] hash file contents and compare (as they contents may change between rebuilds, although not that likely) – likely just push this to filter.