### PR TITLE
Upgrade Minimum JSCS Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "broccoli-static-compiler": "^0.2.1",
     "ember-cli-version-checker": "^1.0.2",
     "js-string-escape": "^1.0.0",
-    "jscs": "^2.0.0",
+    "jscs": "^2.3.2",
     "json-stable-stringify": "^1.0.0",
     "minimatch": "^2.0.1",
     "path": "^0.11.14"


### PR DESCRIPTION
JSCS 2.3.2 fixes a few critical bugs for those using ES6 syntax (`disallowParenthesesAroundArrowParam` was the stopper for my current project).

After upgrading the minimum version, all unit tests still pass and I haven't seen any issues when running against our large-ish Ember CLI application.