### PR TITLE
Allow for supplying config in code

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ Default: **'.jscsrc'**
 
 ---
 
+`options.config` *{Object}*
+
+Specify the options for JSCS programatically, accepts the same kind of JSON
+style object as you would provide in the `.jscsrc` file. This option will be
+overriden when a `.jscsrc` file is in the root or when `options.configPath` is
+set.
+
+Default: **'{}'**
+
+---
+
 `options.enabled` *{true|false}*
 
 This will eliminate processing altogether.

--- a/index.js
+++ b/index.js
@@ -40,7 +40,8 @@ var JSCSFilter = function(inputTree, _options) {
   }
 
   if (this.enabled) {
-    this.rules = config.load(this.configPath || '.jscsrc') || {};
+    this.rules = config.load(this.configPath || '.jscsrc') || this.config || {};
+
     if (!(this.bypass = !Object.keys(this.rules).length)) {
       var checker = new jscs({ esnext: !!this.esnext });
       checker.registerDefaultRules();

--- a/tests/fixtures/code-config/index.js
+++ b/tests/fixtures/code-config/index.js
@@ -1,0 +1,3 @@
+function test() {
+	return null;
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -80,6 +80,21 @@ describe('broccoli-jscs', function() {
         expect(loggerOutput.length).to.not.eql(0);
       });
     });
+
+    it('supply your own in code config object', function() {
+      var sourcePath = 'tests/fixtures/code-config';
+
+      var tree = new jscsTree(sourcePath, {
+        persist: false,
+        config: { "validateIndentation": 2 },
+        logError: function(message) { loggerOutput.push(message); }
+      });
+
+      builder = new broccoli.Builder(tree);
+      return builder.build().then(function() {
+        expect(loggerOutput.length).to.not.eql(0);
+      });
+    });
   });
 
   describe('options', function() {


### PR DESCRIPTION
This seems like an edge case, but it would be nice to have this.
One case would be for example dockyard/ember-suave#77.
To enable a single rule in a test.