### PR TITLE
Add Mocha Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ Default: **false**
 
 ---
 
+`options.testFramework` *{String}*
+
+This setting determines what kind of tests are generated. If a custom `testGenerator` is set `testFramework` will be ignored.
+
+This setting currently supports the following test frameworks:
+
+* `qunit` *(default)*
+* `mocha`
+
+---
+
 `options.testGenerator` *{Function}*
 
 The function used to generate test modules. You can provide a custom function for your client side testing framework of choice.

--- a/index.js
+++ b/index.js
@@ -110,10 +110,19 @@ JSCSFilter.prototype.testGenerator = function(relativePath, errors) {
     errors = this.escapeErrorString('\n' + errors);
   }
 
-  return "module('JSCS - " + path.dirname(relativePath) + "');\n" +
-         "test('" + relativePath + " should pass jscs', function() {\n" +
-         "  ok(" + !errors + ", '" + relativePath + " should pass jscs." + errors + "');\n" +
-         "});\n";
+  if (this.testFramework === 'mocha') {
+    return "describe('JSCS - " + relativePath + "', function() {\n" +
+           "  it('should pass jscs', function() {\n" +
+           "    expect(" + !errors + ", '" + relativePath + " should pass jscs." + errors + "').to.be.ok;\n" +
+           "  });\n" +
+           "});\n";
+
+  } else {
+    return "module('JSCS - " + path.dirname(relativePath) + "');\n" +
+           "test('" + relativePath + " should pass jscs', function() {\n" +
+           "  ok(" + !errors + ", '" + relativePath + " should pass jscs." + errors + "');\n" +
+           "});\n";
+  }
 };
 
 JSCSFilter.prototype.logError = function(message) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -248,7 +248,7 @@ describe('broccoli-jscs', function() {
       });
     });
 
-    it('generates test files with custom test generator', function() {
+    it('generates test files for the mocha test framework', function() {
       var sourcePath = 'tests/fixtures/no-issues-found';
 
       var tree = jscsTree(sourcePath, {

--- a/tests/index.js
+++ b/tests/index.js
@@ -231,6 +231,22 @@ describe('broccoli-jscs', function() {
         expect(readFile(dir + '/good-file.' + tree.targetExtension)).to.be(readFile(sourcePath + '/good-file.js'));
       });
     });
+
+    it('generates test files with custom test generator', function() {
+      var sourcePath = 'tests/fixtures/no-issues-found';
+
+      var tree = jscsTree(sourcePath, {
+        testGenerator: function() {
+          return 'foo';
+        }
+      });
+
+      builder = new broccoli.Builder(tree);
+      return builder.build().then(function(results) {
+        var dir = results.directory;
+        expect(readFile(dir + '/index.' + tree.targetExtension)).to.equal('foo');
+      });
+    });
   });
 
   describe('excludeFiles', function() {

--- a/tests/index.js
+++ b/tests/index.js
@@ -247,6 +247,20 @@ describe('broccoli-jscs', function() {
         expect(readFile(dir + '/index.' + tree.targetExtension)).to.equal('foo');
       });
     });
+
+    it('generates test files with custom test generator', function() {
+      var sourcePath = 'tests/fixtures/no-issues-found';
+
+      var tree = jscsTree(sourcePath, {
+        testFramework: 'mocha'
+      });
+
+      builder = new broccoli.Builder(tree);
+      return builder.build().then(function(results) {
+        var dir = results.directory;
+        expect(readFile(dir + '/index.' + tree.targetExtension)).to.match(/expect\(true, 'index.js should pass jscs.'\).to.be.ok;/);
+      });
+    });
   });
 
   describe('excludeFiles', function() {


### PR DESCRIPTION
This PR adds support for the mocha test framework by setting `testFramework: 'mocha'`.

Due to the broken test suite I've currently based this on the #58 branch. Please let me know if you need me to rebase.

resolves #27 