### PR TITLE
Fix .jscsrc path issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var path      = require('path');
 var minimatch = require('minimatch');
 var stringify = require('json-stable-stringify');
 var crypto    = require('crypto');
+var findup    = require('findup-sync');
 
 var jsStringEscape = require('js-string-escape');
 
@@ -74,7 +75,11 @@ JSCSFilter.prototype.configure = function () {
 };
 
 JSCSFilter.prototype.loadRules = function (rootPath) {
-  return config.load(this.configPath || path.join(rootPath, '.jscsrc')) || this.config || {};
+  return config.load(this.configPath || this.findJSCSRC(rootPath)) || this.config || {};
+};
+
+JSCSFilter.prototype.findJSCSRC = function (rootPath) {
+  return findup('.jscsrc', {cwd: rootPath, nocase: true});
 };
 
 JSCSFilter.prototype.processString = function(content, relativePath) {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "broccoli-persistent-filter": "^1.0.3",
     "broccoli-static-compiler": "^0.2.1",
     "ember-cli-version-checker": "^1.0.2",
+    "findup-sync": "^0.3.0",
     "js-string-escape": "^1.0.0",
     "jscs": "^2.0.0",
     "json-stable-stringify": "^1.0.0",

--- a/tests/index.js
+++ b/tests/index.js
@@ -44,6 +44,20 @@ describe('broccoli-jscs', function() {
       expect(tree.bypass).to.not.be.ok();
     });
 
+    it('defaults to .jscsrc in source path folder', function() {
+      var sourcePath = 'tests/fixtures/issue-found';
+
+      var tree = new jscsTree(sourcePath, {
+        persist: false,
+        logError: function(message) { loggerOutput.push(message); }
+      });
+
+      builder = new broccoli.Builder(tree);
+      return builder.build().then(function() {
+        expect(loggerOutput.join('\n')).to.contain('Expected indentation of 2 characters');
+      });
+    });
+
     it('uses the jscsrc as configuration', function() {
       var sourcePath = 'tests/fixtures/issue-found';
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -55,7 +55,7 @@ describe('broccoli-jscs', function() {
 
       builder = new broccoli.Builder(tree);
       return builder.build().then(function() {
-        expect(loggerOutput.length).to.not.eql(0);
+        expect(loggerOutput.join('\n')).to.contain('Expected indentation of 2 characters');
       });
     });
 


### PR DESCRIPTION
This PR should resolve #65 by looking for the `.jscsrc` file not only in the source tree folder, but also in parent folders until it finds one. This is roughly similar to how `broccoli-jshint` is looking for the `.jshintrc` file too.