### PR TITLE
Updating JSCS to final major release ver ^3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ var app = new EmberApp({
   jscsOptions: {
     configPath: '/my/path/.jscsrc',
     enabled: true,
-    esnext: true,
     disableTestGenerator: false
   }
 });
@@ -39,7 +38,6 @@ You can also supply the options in the `.jscsrc` file if you wish:
 
 ```js
 {
-  "esnext": true,
   "excludeFiles": ["path/to/file"],
   // more rules...
 }
@@ -74,14 +72,6 @@ Default: **'{}'**
 `options.enabled` *{true|false}*
 
 This will eliminate processing altogether.
-
-Default: **false**
-
----
-
-`options.esnext` *{true|false}*
-
-Support ES6 module syntax.
 
 Default: **false**
 

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ JSCSFilter.prototype.configure = function () {
 
     this.bypass = Object.keys(this.rules).length === 0;
     if (!this.bypass) {
-      var checker = new jscs({ esnext: !!this.esnext });
+      var checker = new jscs();
       checker.registerDefaultRules();
       checker.configure(this.rules);
       this.checker = checker;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "ember-cli-version-checker": "^1.0.2",
     "findup-sync": "^0.4.0",
     "js-string-escape": "^1.0.0",
-    "jscs": "^2.0.0",
+    "jscs": "^3.0.0",
     "json-stable-stringify": "^1.0.0",
     "minimatch": "^3.0.0"
   },

--- a/tests/fixtures/esnext-parse-error/.jscsrc
+++ b/tests/fixtures/esnext-parse-error/.jscsrc
@@ -1,4 +1,3 @@
 {
-  "esnext": true,
   "excludeFiles": ["*bad-file.js"]
 }


### PR DESCRIPTION
Updating to `JSCS@^3.0.0` and removing esnext option as it will now be [enabled by default](https://github.com/jscs-dev/node-jscs/commit/ecbb236e3b646991f795ec1ec5e5e8874d1dadfd) using [CST](https://github.com/cst/cst)

See:
https://medium.com/@markelog/jscs-end-of-the-line-bc9bf0b3fdb2#.wxe19qcmi
https://github.com/jscs-dev/node-jscs/releases/tag/v3.0.0
