### PR TITLE
Use `|` as separator for QUnit

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ JSCSFilter.prototype.testGenerator = function(relativePath, errors) {
            "});\n";
 
   } else {
-    return "module('JSCS - " + path.dirname(relativePath) + "');\n" +
+    return "module('JSCS | " + path.dirname(relativePath) + "');\n" +
            "test('" + relativePath + " should pass jscs', function() {\n" +
            "  ok(" + !errors + ", '" + relativePath + " should pass jscs." + errors + "');\n" +
            "});\n";


### PR DESCRIPTION
Ember uses `|` to separate the type of test from the actual test. e.g.

`Acceptance | Login page: lorem ipsum`.

This PR changes the jscs auto generated tests names to something like

`JSCS | app/routes/application.js: should pass jscs`